### PR TITLE
StringCompression

### DIFF
--- a/5kbag/5kbag.csproj
+++ b/5kbag/5kbag.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/5kbag/5kbag.csproj
+++ b/5kbag/5kbag.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StringCompression.cs" />
     <Compile Include="StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/5kbag/Program.cs
+++ b/5kbag/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using _5kbag;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -6,7 +7,7 @@ namespace _5kbag
 {
     class Program
     {
-       
+
         #region "defaults for project.  This area should be ok"
         /// <summary>
         /// how much memory we are able to use
@@ -23,7 +24,7 @@ namespace _5kbag
         /// </summary>
         /// <param name="elements"></param>
         /// <returns></returns>
-        private static IList getList(int elements)
+        private static List<uint> getList(int elements)
         {
             Random rnd = new Random();
             var retVal = new List<uint>();
@@ -44,7 +45,7 @@ namespace _5kbag
         {
             var list = getList(1024 * (totalMemory + 1));  //5k list of numbers
 
-            foreach (var item in list)
+            foreach (uint item in list)
             {
 
                 #region "Your task is to make this block work.  make the Poke and Peek methods"
@@ -60,7 +61,7 @@ namespace _5kbag
 
             //done.  now lets test
             for (var loc = 0; loc < list.Count - 1; loc++)
-                if (list[loc] != memory.Peek[loc])  //please make this line work also
+                if (list[loc] != memory.Peek(loc))  //please make this line work also
                     throw new NotFiniteNumberException();
             Console.WriteLine("Success!");
 

--- a/5kbag/Program.cs
+++ b/5kbag/Program.cs
@@ -1,6 +1,4 @@
-﻿using _5kbag;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 
 namespace _5kbag

--- a/5kbag/Program.cs
+++ b/5kbag/Program.cs
@@ -15,7 +15,7 @@ namespace _5kbag
         /// <summary>
         /// our actual memory container
         /// </summary>
-        public static string memory = new string(' ', 1024 * totalMemory);  //you can change to another container if necessary
+        public static string memory = string.Empty;  //you can change to another container if necessary
 
         /// <summary>
         /// generates a random list of numbers, range from 0 to 65535.  This code is ok; shouldn't need to be fixed.
@@ -42,16 +42,10 @@ namespace _5kbag
         static void Main(string[] args)
         {
             var list = getList(1024 * (totalMemory + 1));  //5k list of numbers
-
+            int memoryLocation = 0;
             foreach (uint item in list)
             {
-
-                #region "Your task is to make this block work.  make the Poke and Peek methods"
-                int memoryLocation = 0;  // this is the actual memory location we are going to update
-
-                memory.Poke(memoryLocation, item);  //we are going to add the item to the memory container.  you are going to have to write Poke
-                #endregion
-
+                memory = memory.Poke(memoryLocation++, item);
 
                 if (memory.Length > 1024 * totalMemory)
                     throw new OutOfMemoryException();
@@ -61,9 +55,11 @@ namespace _5kbag
             for (var loc = 0; loc < list.Count - 1; loc++)
                 if (list[loc] != memory.Peek(loc))  //please make this line work also
                     throw new NotFiniteNumberException();
+
             Console.WriteLine("Success!");
-
-
+            Console.WriteLine(1024 * totalMemory);
+            Console.WriteLine(memory.Length);
+            Console.ReadLine();
         }
     }
 }

--- a/5kbag/StringCompression.cs
+++ b/5kbag/StringCompression.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace _5kbag
+{
+    public static class StringCompression
+    {
+        public static string Compress(this string text)
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes(text);
+            MemoryStream ms = new MemoryStream();
+            using (GZipStream zip = new GZipStream(ms, CompressionMode.Compress, true))
+                zip.Write(buffer, 0, buffer.Length);
+
+            ms.Position = 0;
+            MemoryStream outStream = new MemoryStream();
+
+            byte[] compressed = new byte[ms.Length];
+            ms.Read(compressed, 0, compressed.Length);
+
+            byte[] gzBuffer = new byte[compressed.Length + 4];
+            Buffer.BlockCopy(compressed, 0, gzBuffer, 4, compressed.Length);
+            Buffer.BlockCopy(BitConverter.GetBytes(buffer.Length), 0, gzBuffer, 0, 4);
+            return Convert.ToBase64String(gzBuffer);
+        }
+
+        public static string Decompress(this string compressedText)
+        {
+            if (string.IsNullOrEmpty(compressedText)) return "";
+            byte[] gzBuffer = Convert.FromBase64String(compressedText);
+            using (MemoryStream ms = new MemoryStream())
+            {
+                int msgLength = BitConverter.ToInt32(gzBuffer, 0);
+                ms.Write(gzBuffer, 4, gzBuffer.Length - 4);
+
+                byte[] buffer = new byte[msgLength];
+
+                ms.Position = 0;
+                using (GZipStream zip = new GZipStream(ms, CompressionMode.Decompress))
+                    zip.Read(buffer, 0, buffer.Length);
+                return Encoding.UTF8.GetString(buffer);
+            }
+        }
+    }
+}

--- a/5kbag/StringExtensions.cs
+++ b/5kbag/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace _5kbag
+{
+    public static class StringExtensions
+    {
+        public static void Poke(this string value, int loc, uint item)
+        {
+            //
+        }
+
+        public static uint Peek(this string value, int loc)
+        {
+            return 0;
+        }
+    }
+}

--- a/5kbag/StringExtensions.cs
+++ b/5kbag/StringExtensions.cs
@@ -2,14 +2,23 @@
 {
     public static class StringExtensions
     {
-        public static void Poke(this string value, int loc, uint item)
+        public static string Poke(this string value, int loc, uint item)
         {
-            //
+            string tmp = value.Decompress();
+            int last = 0;
+            foreach (char c in tmp)
+                last += c - '0';
+            tmp += (item - last).ToString();
+            return tmp.Compress();
         }
 
         public static uint Peek(this string value, int loc)
         {
-            return 0;
+            string tmp = value.Decompress();
+            int num = 0;
+            for (int i = 0; i <= loc; i++)
+                num += tmp[i] - '0';
+            return (uint)num;
         }
     }
 }


### PR DESCRIPTION
We know that the items are a list numbers in incremental order.
I take advantage of that and subtract the number and the predecessor, that way we only "store" one char per position, and of course GZip the final string.

In my tests I can manage to get a memory.Length ~ 3390